### PR TITLE
remove snapshot for cache

### DIFF
--- a/src/cache.d.ts
+++ b/src/cache.d.ts
@@ -7,7 +7,6 @@ export type Snapshot = ReturnType<WebpackCompilation['fileSystemInfo']['mergeSna
  * @template TResult
  *
  * @param {string[]} absoluteFilePaths - file paths used used by the generator
- * @param {any} pluginInstance - the plugin instance to use as cache key
  * @param {boolean} useWebpackCache - Support webpack built in cache
  * @param {WebpackCompilation} compilation - the current webpack compilation
  * @param {string[]} eTags - eTags to verify the string
@@ -16,7 +15,7 @@ export type Snapshot = ReturnType<WebpackCompilation['fileSystemInfo']['mergeSna
  *
  * @returns {Promise<TResult>}
  */
-export function runCached<TResult>(absoluteFilePaths: string[], pluginInstance: any, useWebpackCache: boolean, compilation: WebpackCompilation, eTags: string[], idGenerator: (files: {
+export function runCached<TResult>(absoluteFilePaths: string[], useWebpackCache: boolean, compilation: WebpackCompilation, eTags: string[], idGenerator: (files: {
     filePath: string;
     hash: string;
     content: Buffer;

--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,6 @@ class FaviconsWebpackPlugin {
 
         const faviconCompilation = runCached(
           [...this.#options.logo, ...logoMaskable, manifestAbsoluteFilePath],
-          this,
           this.#options.cache,
           compilation,
           // Options which enforce a new recompilation


### PR DESCRIPTION
This pull request includes changes to `src/cache.js` and `src/index.js` that simplify the caching mechanism by removing the use of `WeakMap` for caching snapshots and favicons. The `pluginInstance` parameter, which was previously used as a key for these caches, has also been removed from the `runCached` function.

Changes to `src/cache.js`:

* Removed the `WeakMap` instances `snapshots` and `faviconCache` that were previously used for caching. This simplifies the caching mechanism by removing the need to manage these caches.
* Updated the `runCached` function to remove the use of `pluginInstance` as a key for the `snapshots` and `faviconCache`. This simplifies the function by reducing the number of parameters and removing the need to manage these caches. [[1]](diffhunk://#diff-3fb1021e8b65be53e466751de219baf5282edb86a3a1ad8fe429cac948991af7L55-L99) [[2]](diffhunk://#diff-3fb1021e8b65be53e466751de219baf5282edb86a3a1ad8fe429cac948991af7L113-L115)

Change to `src/index.js`:

* Removed the `this` parameter from the `runCached` function call in `FaviconsWebpackPlugin`. This change is aligned with the update to `runCached` in `src/cache.js`.