### PR TITLE
remove peerDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "parse5": "^7.1.1"
       },
       "devDependencies": {
-        "@rspack/cli": "0.7.0",
-        "@rspack/core": "0.7.0",
+        "@rspack/cli": "^0.7.0",
+        "@rspack/core": "^0.7.0",
         "ava": "^5.1.0",
         "commitizen": "^4.2.5",
         "cz-conventional-changelog": "^3.3.0",
@@ -39,7 +39,6 @@
         "html-rspack-plugin": "^5.7.0"
       },
       "peerDependencies": {
-        "@rspack/core": "^0.7.0",
         "favicons": "^7.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
     "parse5": "^7.1.1"
   },
   "peerDependencies": {
-    "favicons": "^7.0.1",
-    "@rspack/core": "^0.7.0"
+    "favicons": "^7.0.1"
   },
   "optionalDependencies": {
     "html-rspack-plugin": "^5.7.0"


### PR DESCRIPTION
This pull request includes a change to the `package.json` file to update the project's dependencies. The most important change is the removal of the `@rspack/core` dependency from the `peerDependencies` section.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L71-R71): Removed the `@rspack/core` dependency from the `peerDependencies` section.